### PR TITLE
v0.8 lib-ahttp Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ahttp - aah framework
-[![Build Status](https://travis-ci.org/go-aah/ahttp.svg?branch=master)](https://travis-ci.org/go-aah/ahttp) [![codecov](https://codecov.io/gh/go-aah/ahttp/branch/master/graph/badge.svg)](https://codecov.io/gh/go-aah/ahttp/branch/master) [![Go Report Card](https://goreportcard.com/badge/aahframework.org/ahttp.v0)](https://goreportcard.com/report/aahframework.org/ahttp.v0) [![Version](https://img.shields.io/badge/version-0.7-blue.svg)](https://github.com/go-aah/ahttp/releases/latest) [![GoDoc](https://godoc.org/aahframework.org/ahttp.v0?status.svg)](https://godoc.org/aahframework.org/ahttp.v0)  [![License](https://img.shields.io/github/license/go-aah/ahttp.svg)](LICENSE)
+[![Build Status](https://travis-ci.org/go-aah/ahttp.svg?branch=master)](https://travis-ci.org/go-aah/ahttp) [![codecov](https://codecov.io/gh/go-aah/ahttp/branch/master/graph/badge.svg)](https://codecov.io/gh/go-aah/ahttp/branch/master) [![Go Report Card](https://goreportcard.com/badge/aahframework.org/ahttp.v0)](https://goreportcard.com/report/aahframework.org/ahttp.v0) [![Version](https://img.shields.io/badge/version-0.8-blue.svg)](https://github.com/go-aah/ahttp/releases/latest) [![GoDoc](https://godoc.org/aahframework.org/ahttp.v0?status.svg)](https://godoc.org/aahframework.org/ahttp.v0)  [![License](https://img.shields.io/github/license/go-aah/ahttp.svg)](LICENSE)
 
-***v0.7 [released](https://github.com/go-aah/ahttp/releases/latest) and tagged on Jun 02, 2017***
+***v0.8 [released](https://github.com/go-aah/ahttp/releases/latest) and tagged on Jun 07, 2017***
 
 HTTP Library built to process, manipulate Request and Response (headers, body, gzip, etc).
 

--- a/ahttp.go
+++ b/ahttp.go
@@ -13,15 +13,15 @@ const Version = "0.7"
 
 // HTTP Method names
 const (
-	MethodGet     = "GET"
-	MethodHead    = "HEAD"
-	MethodOptions = "OPTIONS"
-	MethodPost    = "POST"
-	MethodPut     = "PUT"
-	MethodPatch   = "PATCH"
-	MethodDelete  = "DELETE"
-	MethodConnect = "CONNECT"
-	MethodTrace   = "TRACE"
+	MethodGet     = http.MethodGet
+	MethodHead    = http.MethodHead
+	MethodOptions = http.MethodOptions
+	MethodPost    = http.MethodPost
+	MethodPut     = http.MethodPut
+	MethodPatch   = http.MethodPatch
+	MethodDelete  = http.MethodDelete
+	MethodConnect = http.MethodConnect
+	MethodTrace   = http.MethodTrace
 )
 
 // TimeFormat is the time format to use when generating times in HTTP

--- a/content_type.go
+++ b/content_type.go
@@ -92,14 +92,15 @@ type (
 // Content-Type methods
 //___________________________________
 
-// IsEqual method compare give Content-Type string wth instance.
+// IsEqual method compares give Content-Type string with current instance.
 //    E.g.:
 //      contentType.IsEqual("application/json")
 func (c *ContentType) IsEqual(contentType string) bool {
 	return strings.HasPrefix(c.Raw(), strings.ToLower(contentType))
 }
 
-// Charset returns charset of content-type otherwise `defaultCharset` is returned
+// Charset method returns charset of content-type
+// otherwise `defaultCharset` is returned
 // 	For e.g.:
 // 		Content-Type: application/json; charset=utf-8
 //
@@ -111,14 +112,36 @@ func (c *ContentType) Charset(defaultCharset string) string {
 	return defaultCharset
 }
 
-// Version returns Accept header version paramater value if present otherwise
-// empty string
+// Version method returns Accept header version paramater value if present
+// otherwise empty string
 // 	For e.g.:
 // 		Accept: application/json; version=2
+// 		Accept: application/vnd.mycompany.myapp.customer-v2+json
 //
 // 		Method returns `2`
 func (c *ContentType) Version() string {
-	if v, ok := c.Params["version"]; ok {
+	return c.GetParam("version")
+}
+
+// Vendor method returns Accept header vendor info if present
+// otherwise empty string
+// 	For e.g.:
+// 		Accept: application/vnd.mycompany.myapp.customer-v2+json
+//
+// 		Method returns `mycompany.myapp.customer`
+func (c *ContentType) Vendor() string {
+	return c.GetParam("vendor")
+}
+
+// GetParam method returns the media type paramater of Accept Content-Type header
+// otherwise returns empty string
+// value.
+// 	For e.g.:
+// 		Accept: application/json; version=2
+//
+// 		Method returns `2` for key `version`
+func (c *ContentType) GetParam(key string) string {
+	if v, found := c.Params[key]; found {
 		return v
 	}
 	return ""

--- a/content_type.go
+++ b/content_type.go
@@ -11,72 +11,31 @@ import (
 
 var (
 	// ContentTypeHTML HTML content type.
-	ContentTypeHTML = &ContentType{
-		Mime: "text/html",
-		Exts: []string{".html", ".htm"},
-		Params: map[string]string{
-			"charset": "utf-8",
-		},
-	}
+	ContentTypeHTML = parseMediaType("text/html; charset=utf-8")
 
 	// ContentTypeJSON JSON content type.
-	ContentTypeJSON = &ContentType{
-		Mime: "application/json",
-		Exts: []string{".json"},
-		Params: map[string]string{
-			"charset": "utf-8",
-		},
-	}
+	ContentTypeJSON = parseMediaType("application/json; charset=utf-8")
 
 	// ContentTypeJSONText JSON text content type.
-	ContentTypeJSONText = &ContentType{
-		Mime: "text/json",
-		Exts: []string{".json"},
-		Params: map[string]string{
-			"charset": "utf-8",
-		},
-	}
+	ContentTypeJSONText = parseMediaType("text/json; charset=utf-8")
 
 	// ContentTypeXML XML content type.
-	ContentTypeXML = &ContentType{
-		Mime: "application/xml",
-		Exts: []string{".xml"},
-		Params: map[string]string{
-			"charset": "utf-8",
-		},
-	}
+	ContentTypeXML = parseMediaType("application/xml; charset=utf-8")
 
 	// ContentTypeXMLText XML text content type.
-	ContentTypeXMLText = &ContentType{
-		Mime: "text/xml",
-		Exts: []string{".xml"},
-		Params: map[string]string{
-			"charset": "utf-8",
-		},
-	}
+	ContentTypeXMLText = parseMediaType("text/xml; charset=utf-8")
 
 	// ContentTypeMultipartForm form data and File.
-	ContentTypeMultipartForm = &ContentType{
-		Mime: "multipart/form-data",
-	}
+	ContentTypeMultipartForm = parseMediaType("multipart/form-data")
 
 	// ContentTypeForm form data type.
-	ContentTypeForm = &ContentType{
-		Mime: "application/x-www-form-urlencoded",
-	}
+	ContentTypeForm = parseMediaType("application/x-www-form-urlencoded")
 
 	// ContentTypePlainText content type.
-	ContentTypePlainText = &ContentType{
-		Mime: "text/plain",
-		Params: map[string]string{
-			"charset": "utf-8",
-		},
-	}
+	ContentTypePlainText = parseMediaType("text/plain; charset=utf-8")
 
 	// ContentTypeOctetStream content type for bytes.
-	ContentTypeOctetStream = &ContentType{
-		Mime: "application/octet-stream",
-	}
+	ContentTypeOctetStream = parseMediaType("application/octet-stream")
 )
 
 type (

--- a/content_type_test.go
+++ b/content_type_test.go
@@ -67,7 +67,6 @@ func TestHTTPNegotiateContentType(t *testing.T) {
 	req = createRawHTTPRequest(HeaderAccept, "application/json; version")
 	spec = ParseAccept(req, HeaderAccept).MostQualified()
 	assert.Equal(t, "", spec.GetParam("version", "1"))
-
 }
 
 func TestHTTPParseContentType(t *testing.T) {

--- a/content_type_test.go
+++ b/content_type_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"testing"
 
+	"aahframework.org/essentials.v0"
 	"aahframework.org/test.v0/assert"
 )
 
@@ -34,7 +35,7 @@ func TestHTTPNegotiateContentType(t *testing.T) {
 	contentType = NegotiateContentType(req4)
 	assert.Equal(t, "text/html; charset=utf-8", contentType.String())
 	assert.True(t, contentType.IsEqual("text/html"))
-	assert.Equal(t, ".html", contentType.Exts[0])
+	assert.True(t, ess.IsSliceContainsString(contentType.Exts, ".html"))
 	assert.Equal(t, "", contentType.Version())
 
 	req := createRawHTTPRequest(HeaderAccept, "application/json")
@@ -46,8 +47,8 @@ func TestHTTPNegotiateContentType(t *testing.T) {
 	req = createRawHTTPRequest(HeaderAccept, "application/json")
 	req.URL, _ = url.Parse("http://localhost:8080/testpath.html")
 	contentType = NegotiateContentType(req)
-	assert.Equal(t, "text/html; charset=utf-8", contentType.Mime)
-	assert.Equal(t, ".html", contentType.Exts[0])
+	assert.Equal(t, "text/html", contentType.Mime)
+	assert.True(t, ess.IsSliceContainsString(contentType.Exts, ".html"))
 
 	req = createRawHTTPRequest(HeaderAccept, "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8")
 	contentType = NegotiateContentType(req)
@@ -92,11 +93,11 @@ func TestHTTPParseContentType(t *testing.T) {
 	contentType = ParseContentType(req4)
 	assert.Equal(t, "text/html", contentType.Mime)
 	assert.Equal(t, "text/html; charset=utf-8", contentType.String())
-	assert.Equal(t, ".html", contentType.Exts[0])
+	assert.True(t, ess.IsSliceContainsString(contentType.Exts, ".html"))
 
 	req5 := createRawHTTPRequest(HeaderContentType, "text/html;charset")
 	contentType = ParseContentType(req5)
-	assert.Equal(t, "text/html", contentType.Mime)
-	assert.Equal(t, "text/html; charset=", contentType.String())
-	assert.Equal(t, "", contentType.Charset("iso-8859-1"))
+	assert.Equal(t, "", contentType.Mime)
+	assert.Equal(t, "", contentType.String())
+	assert.Equal(t, "iso-8859-1", contentType.Charset("iso-8859-1"))
 }

--- a/header_test.go
+++ b/header_test.go
@@ -116,6 +116,32 @@ func TestHTTPNegotiateEncoding(t *testing.T) {
 	assert.False(t, isGzipAccepted(&Request{}, req4))
 }
 
+func TestHTTPAcceptHeaderVendorType(t *testing.T) {
+	req := createRawHTTPRequest(HeaderAccept, "application/vnd.mycompany.myapp.customer-v2.2+json")
+	ctype := NegotiateContentType(req)
+	assert.Equal(t, "application/json", ctype.Mime)
+	assert.Equal(t, "mycompany.myapp.customer", ctype.Vendor())
+	assert.Equal(t, "2.2", ctype.Version())
+
+	req = createRawHTTPRequest(HeaderAccept, "application/vnd.mycompany.myapp.customer+json")
+	ctype = NegotiateContentType(req)
+	assert.Equal(t, "application/json", ctype.Mime)
+	assert.Equal(t, "mycompany.myapp.customer", ctype.Vendor())
+	assert.Equal(t, "", ctype.Version())
+
+	req = createRawHTTPRequest(HeaderAccept, "application/vnd.api+json")
+	ctype = NegotiateContentType(req)
+	assert.Equal(t, "application/json", ctype.Mime)
+	assert.Equal(t, "api", ctype.Vendor())
+	assert.Equal(t, "", ctype.Version())
+
+	req = createRawHTTPRequest(HeaderAccept, "application/json")
+	ctype = NegotiateContentType(req)
+	assert.Equal(t, "application/json", ctype.Mime)
+	assert.Equal(t, "", ctype.Vendor())
+	assert.Equal(t, "", ctype.Version())
+}
+
 func createRawHTTPRequest(hdrKey, value string) *http.Request {
 	hdr := http.Header{}
 	hdr.Set(hdrKey, value)

--- a/request.go
+++ b/request.go
@@ -27,7 +27,7 @@ type (
 		//  - `X-Forwarded-Proto` is not empty return value as is
 		//  - `http.Request.TLS` is not nil value is `https`
 		//  - `http.Request.TLS` is nil value is `http`
-		Schema string
+		Scheme string
 
 		// Host value of the HTTP 'Host' header (e.g. 'example.com:8080').
 		Host string
@@ -99,7 +99,7 @@ type (
 // ParseRequest method populates the given aah framework `ahttp.Request`
 // instance from Go HTTP request.
 func ParseRequest(r *http.Request, req *Request) *Request {
-	req.Schema = identifyScheme(r)
+	req.Scheme = identifyScheme(r)
 	req.Host = host(r)
 	req.Method = r.Method
 	req.Path = r.URL.Path
@@ -177,7 +177,7 @@ func (r *Request) FormFile(key string) (multipart.File, *multipart.FileHeader, e
 
 // Reset method resets request instance for reuse.
 func (r *Request) Reset() {
-	r.Schema = ""
+	r.Scheme = ""
 	r.Host = ""
 	r.Method = ""
 	r.Path = ""

--- a/request.go
+++ b/request.go
@@ -23,7 +23,7 @@ const (
 type (
 	// Request is extends `http.Request` for aah framework
 	Request struct {
-		// Schema value is protocol info; it's a derived value in the order as below.
+		// Scheme value is protocol; it's a derived value in the order as below.
 		//  - `X-Forwarded-Proto` is not empty return value as is
 		//  - `http.Request.TLS` is not nil value is `https`
 		//  - `http.Request.TLS` is nil value is `http`
@@ -41,23 +41,25 @@ type (
 		// Header request HTTP headers
 		Header http.Header
 
-		// Payload holds the value from HTTP request for `Content-Type`
-		// JSON and XML.
-		Payload []byte
-
-		// ContentType the parsed HTTP header `Content-Type`.
+		// ContentType the parsed value of HTTP header `Content-Type`.
+		// Partial implementation as per RFC1521.
 		ContentType *ContentType
 
 		// AcceptContentType negotiated value from HTTP Header `Accept`.
 		// The resolve order is-
 		// 1) URL extension
-		// 2) Accept header.
+		// 2) Accept header (As per RFC7231 and vendor type as per RFC4288)
 		// Most quailfied one based on quality factor otherwise default is HTML.
 		AcceptContentType *ContentType
 
 		// AcceptEncoding negotiated value from HTTP Header the `Accept-Encoding`
+		// As per RFC7231.
 		// Most quailfied one based on quality factor.
 		AcceptEncoding *AcceptSpec
+
+		// Payload holds the value from HTTP request for `Content-Type`
+		// JSON and XML.
+		Payload []byte
 
 		// Params contains values from Path, Query, Form and File.
 		Params *Params
@@ -68,10 +70,12 @@ type (
 		// UserAgent value of the HTTP 'User-Agent' header.
 		UserAgent string
 
-		// ClientIP remote client IP address.
+		// ClientIP remote client IP address aka Remote IP. Parsed in the order of
+		// `X-Forwarded-For`, `X-Real-IP` and finally `http.Request.RemoteAddr`.
 		ClientIP string
 
 		// Locale negotiated value from HTTP Header `Accept-Language`.
+		// As per RFC7231.
 		Locale *Locale
 
 		// IsGzipAccepted is true if the HTTP client accepts Gzip response,
@@ -131,7 +135,8 @@ func (r *Request) Cookies() []*http.Cookie {
 	return r.Raw.Cookies()
 }
 
-// IsJSONP method returns true if request query string has "callback=function_name".
+// IsJSONP method returns true if request URL query string has "callback=function_name".
+// otherwise false.
 func (r *Request) IsJSONP() bool {
 	return !ess.IsStrEmpty(r.QueryValue(jsonpReqParamKey))
 }
@@ -142,29 +147,31 @@ func (r *Request) IsAJAX() bool {
 	return r.Header.Get(HeaderXRequestedWith) == ajaxHeaderValue
 }
 
-// PathValue method return value for given Path param key otherwise empty string.
+// PathValue method returns value for given Path param key otherwise empty string.
+// For eg.: /users/:userId => PathValue("userId")
 func (r *Request) PathValue(key string) string {
 	return r.Params.PathValue(key)
 }
 
-// QueryValue method return value for given query (aka URL) param key
+// QueryValue method returns value for given URL query param key
 // otherwise empty string.
 func (r *Request) QueryValue(key string) string {
 	return r.Params.QueryValue(key)
 }
 
-// QueryArrayValue method return array value for given query (aka URL)
-// param key otherwise empty string.
+// QueryArrayValue method returns array value for given URL query param key
+// otherwise empty string slice.
 func (r *Request) QueryArrayValue(key string) []string {
 	return r.Params.QueryArrayValue(key)
 }
 
-// FormValue methos returns value for given form key otherwise empty string.
+// FormValue method returns value for given form key otherwise empty string.
 func (r *Request) FormValue(key string) string {
 	return r.Params.FormValue(key)
 }
 
-// FormArrayValue methos returns value for given form key otherwise empty string.
+// FormArrayValue method returns array value for given form key
+// otherwise empty string slice.
 func (r *Request) FormArrayValue(key string) []string {
 	return r.Params.FormArrayValue(key)
 }
@@ -182,10 +189,10 @@ func (r *Request) Reset() {
 	r.Method = ""
 	r.Path = ""
 	r.Header = nil
-	r.Payload = nil
 	r.ContentType = nil
 	r.AcceptContentType = nil
 	r.AcceptEncoding = nil
+	r.Payload = nil
 	r.Params = nil
 	r.Referer = ""
 	r.UserAgent = ""
@@ -199,7 +206,8 @@ func (r *Request) Reset() {
 // Params methods
 //___________________________________
 
-// PathValue method return value for given Path param key otherwise empty string.
+// PathValue method returns value for given Path param key otherwise empty string.
+// For eg.: `/users/:userId` => `PathValue("userId")`.
 func (p *Params) PathValue(key string) string {
 	if p.Path != nil {
 		if value, found := p.Path[key]; found {
@@ -209,14 +217,14 @@ func (p *Params) PathValue(key string) string {
 	return ""
 }
 
-// QueryValue method return value for given query (aka URL) param key
+// QueryValue method returns value for given URL query param key
 // otherwise empty string.
 func (p *Params) QueryValue(key string) string {
 	return p.Query.Get(key)
 }
 
-// QueryArrayValue method return array value for given query (aka URL)
-// param key otherwise empty string.
+// QueryArrayValue method returns array value for given URL query param key
+// otherwise empty string slice.
 func (p *Params) QueryArrayValue(key string) []string {
 	if values, found := p.Query[key]; found {
 		return values
@@ -224,7 +232,7 @@ func (p *Params) QueryArrayValue(key string) []string {
 	return []string{}
 }
 
-// FormValue methos returns value for given form key otherwise empty string.
+// FormValue method returns value for given form key otherwise empty string.
 func (p *Params) FormValue(key string) string {
 	if p.Form != nil {
 		return p.Form.Get(key)
@@ -232,7 +240,8 @@ func (p *Params) FormValue(key string) string {
 	return ""
 }
 
-// FormArrayValue methos returns value for given form key otherwise empty string.
+// FormArrayValue method returns array value for given form key
+// otherwise empty string slice.
 func (p *Params) FormArrayValue(key string) []string {
 	if p.Form != nil {
 		if values, found := p.Form[key]; found {
@@ -242,8 +251,8 @@ func (p *Params) FormArrayValue(key string) []string {
 	return []string{}
 }
 
-// FormFile method returns the first file for the provided form key otherwise
-// returns error. It is caller responsibility to close the file.
+// FormFile method returns the first file for the provided form key
+// otherwise returns error. It is caller responsibility to close the file.
 func (p *Params) FormFile(key string) (multipart.File, *multipart.FileHeader, error) {
 	if p.File != nil {
 		if fh := p.File[key]; len(fh) > 0 {


### PR DESCRIPTION
* go-aah/aah#62 accept header vendor types support
* Make use of the HTTP method constants from the standard library - PR #9 @adelowo
* go-aah/aah#60 BugFix Request.Schema should be Request.Scheme - PR #10 @adelowo
* Improved handling of content type header
